### PR TITLE
Ignore Terraform plan files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 # .tfstate files
 *.tfstate
 *.tfstate.*
-
+*.tfplan
 # Crash log files
 crash.log
 crash.*.log


### PR DESCRIPTION
Added '*.tfplan' to .gitignore to prevent Terraform plan files from being tracked in version control.