### PR TITLE
Fix indentation for default value in rg-name variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "rg-name" {
   description = "The name of the Resource Group"
   type        = string
-  default = "rg-cdo-dev-kyncdm"
+  default     = "rg-cdo-dev-kyncdm"
 }
 
 variable "location" {


### PR DESCRIPTION
Corrected the indentation of the 'default' attribute in the 'rg-name' variable for consistency and readability.