### PR TITLE
Add support for multiple resource group deployments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,19 @@
+# module "resource-group" {
+#   source    = "mniranjanr7/resource-group/azurerm"
+#   version   = "1.0.2"
+#   rg-name   = var.rg-name
+#   location  = var.location
+#   snowqueue = var.Snow-Queue-Name
+#   project   = var.project
+
+# }
+
 module "resource-group" {
   source    = "mniranjanr7/resource-group/azurerm"
   version   = "1.0.2"
-  rg-name   = var.rg-name
-  location  = var.location
-  snowqueue = var.Snow-Queue-Name
-  project   = var.project
-
+  for_each  = var.rg-deploy
+  rg-name   = each.value.rg-name
+  location  = each.value.location
+  snowqueue = each.value.Snow-Queue-Name
+  project   = each.value.project
 }

--- a/variables.tf
+++ b/variables.tf
@@ -22,3 +22,34 @@ variable "project" {
   default     = "KYNCDM"
 
 }
+
+variable "rg-deploy" {
+  description = "Flag to deploy Resource Group"
+  type = map(object({
+    Snow-Queue-Name = string
+    project         = string
+    location        = string
+    rg-name         = string
+
+  }))
+  default = {
+    kyncdm = {
+      Snow-Queue-Name = "Data-Platform"
+      project         = "KYNCDM"
+      location        = "East US"
+      rg-name         = "rg-cdo-dev-kyncdm"
+    }
+    piqt = {
+      Snow-Queue-Name = "Data-Platform"
+      project         = "PIQT"
+      location        = "East US 2"
+      rg-name         = "rg-cdo-prod-piqt"
+    }
+    ukibi = {
+      Snow-Queue-Name = "Data-Platform"
+      project         = "ukibi"
+      location        = "Central US"
+      rg-name         = "rg-cdo-prod-ukibi"
+    }
+  }
+}


### PR DESCRIPTION
Refactored resource group module to use for_each for deploying multiple resource groups based on the new rg-deploy variable. Updated variables.tf to define rg-deploy as a map of objects, enabling configuration of multiple resource groups in a single run.